### PR TITLE
More concise input/output driver/compression flags for the main CLI group

### DIFF
--- a/gpsdio/__init__.py
+++ b/gpsdio/__init__.py
@@ -11,7 +11,7 @@ from . import schema
 from . import validate
 
 
-__version__ = '0.0.1'
+__version__ = '0.0.2'
 __author__ = 'Kevin Wurster, Egil Moeller'
 __email__ = 'kevin@skytruth.org, egil@skytruth.org, '
 __source__ = 'https://github.com/SkyTruth/gpsdio'

--- a/gpsdio/cli/commands.py
+++ b/gpsdio/cli/commands.py
@@ -184,8 +184,8 @@ def cat(ctx, infile):
     Print messages to stdout as newline JSON.
     """
 
-    with gpsdio.open(infile, driver=ctx.obj['i_driver'],
-                     compression=ctx.obj['i_compression']) as src, \
+    with gpsdio.open(infile, driver=ctx.obj['i_drv'],
+                     compression=ctx.obj['i_cmp']) as src, \
             gpsdio.open('-', 'w', driver='NewlineJSON', compression=False) as dst:
         for msg in src:
             dst.write(msg)
@@ -201,8 +201,8 @@ def load(ctx, outfile):
     """
 
     with gpsdio.open('-', driver='NewlineJSON', compression=False) as src, \
-            gpsdio.open(outfile, 'w', driver=ctx.obj['o_driver'],
-                        compression=ctx.obj['o_compression']) as dst:
+            gpsdio.open(outfile, 'w', driver=ctx.obj['o_drv'],
+                        compression=ctx.obj['o_cmp']) as dst:
         for msg in src:
             dst.write(msg)
 
@@ -237,8 +237,8 @@ def insp(ctx, infile, use_ipython):
         "Try `help(stream)` or `next(stream)`."
     ))
 
-    with gpsdio.open(infile, driver=ctx.obj['i_driver'],
-                     compression=ctx.obj['i_compression']) as src:
+    with gpsdio.open(infile, driver=ctx.obj['i_drv'],
+                     compression=ctx.obj['i_cmp']) as src:
 
         scope = {
             'stream': src,
@@ -335,10 +335,10 @@ def etl(ctx, infile, outfile, filter_expr, sort_field):
             --sort timestamp
     """
 
-    with gpsdio.open(infile, driver=ctx.obj['i_driver'],
-                     compression=ctx.obj['i_compression']) as src, \
-            gpsdio.open(outfile, 'w', driver=ctx.obj['o_driver'],
-                        compression=ctx.obj['o_compression']) as dst:
+    with gpsdio.open(infile, driver=ctx.obj['i_drv'],
+                     compression=ctx.obj['i_cmp']) as src, \
+            gpsdio.open(outfile, 'w', driver=ctx.obj['o_drv'],
+                        compression=ctx.obj['o_cmp']) as dst:
 
         iterator = gpsdio.filter(src, filter_expr) if filter_expr else src
         for msg in gpsdio.sort(iterator, sort_field) if sort_field else iterator:

--- a/gpsdio/cli/main.py
+++ b/gpsdio/cli/main.py
@@ -17,34 +17,34 @@ import gpsdio.drivers
     p for p in itertools.chain(*(iter_entry_points('gpsdio.gpsdio_commands'),
                                  iter_entry_points('gpsdio.gpsdio_plugins')))))
 @click.option(
-    '--input-driver', metavar='NAME', default=None,
+    '--i-drv', metavar='NAME', default=None,
     help='Specify the input driver.  Normally auto-detected from file path.',
     type=click.Choice(list(gpsdio.drivers.BaseDriver.by_name.keys()))
 )
 @click.option(
-    '--output-driver', metavar='NAME', default=None,
+    '--o-drv', metavar='NAME', default=None,
     help='Specify the output driver.  Normally auto-detected from file path.',
     type=click.Choice(list(gpsdio.drivers.BaseDriver.by_name.keys()))
 )
 @click.option(
-    '--input-compression', metavar='NAME', default=None,
+    '--i-cmp', metavar='NAME', default=None,
     help='Input compression format.  Normally auto-detected from file path.',
     type=click.Choice(list(gpsdio.drivers.BaseCompressionDriver.by_name.keys()))
 )
 @click.option(
-    '--output-compression', metavar='NAME', default=None,
+    '--o-cmp', metavar='NAME', default=None,
     help='Output compression format.  Normally auto-detected from file path.',
     type=click.Choice(list(gpsdio.drivers.BaseCompressionDriver.by_name.keys()))
 )
 @click.pass_context
-def main_group(ctx, input_driver, output_driver, input_compression, output_compression):
+def main_group(ctx, i_drv, o_drv, i_cmp, o_cmp):
     """
     A collection of tools for working with the GPSD JSON format (or the same format in a msgpack container)
     """
 
     ctx.obj = {
-        'i_driver': input_driver,
-        'o_driver': output_driver,
-        'i_compression': input_compression,
-        'o_compression': output_compression
+        'i_drv': i_drv,
+        'o_drv': o_drv,
+        'i_cmp': i_cmp,
+        'o_cmp': o_cmp
     }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,8 +58,8 @@ def test_load():
         print(stdin_input)
 
         result = CliRunner().invoke(gpsdio.cli.main_group, [
-            '--output-driver', 'NewlineJSON',
-            '--output-compression', 'GZIP',
+            '--o-drv', 'NewlineJSON',
+            '--o-cmp', 'GZIP',
             'load',
             dst.name
 
@@ -83,8 +83,8 @@ def test_etl():
     # Process everything and sort on timestamp
     with tempfile.NamedTemporaryFile('r+') as f:
         result = CliRunner().invoke(gpsdio.cli.main_group, [
-            '--output-driver', driver,
-            '--output-compression', comp,
+            '--o-drv', driver,
+            '--o-cmp', comp,
             'etl',
             '--sort', 'timestamp',
             TYPES_MSG_GZ_FILE,
@@ -105,8 +105,8 @@ def test_etl():
     # Process everything and sort on mmsi
     with tempfile.NamedTemporaryFile('r+') as f:
         result = CliRunner().invoke(gpsdio.cli.main_group, [
-            '--output-driver', driver,
-            '--output-compression', comp,
+            '--o-drv', driver,
+            '--o-cmp', comp,
             'etl',
             '--sort', 'mmsi',
             TYPES_MSG_GZ_FILE,
@@ -127,8 +127,8 @@ def test_etl():
     # Filter and process
     with tempfile.NamedTemporaryFile('r+') as f:
         result = CliRunner().invoke(gpsdio.cli.main_group, [
-            '--output-driver', driver,
-            '--output-compression', comp,
+            '--o-drv', driver,
+            '--o-cmp', comp,
             'etl',
             '--filter', "lat and lon",
             '--sort', 'lat',


### PR DESCRIPTION
The old ones were too long and the keys in `ctx.obj` were cumbersome.