### PR TITLE
Drivers implement an open() method

### DIFF
--- a/gpsdio/base.py
+++ b/gpsdio/base.py
@@ -68,11 +68,11 @@ class BaseDriver(six.with_metaclass(_RegisterDriver, object)):
             An object provided by a driver that behaves like `file`.
         """
 
+        if mode not in self.io_modes:
+            raise ValueError("Mode '{mode}' is unsupported: {io_modes}"
+                             .format(mode=mode, io_modes=str(self.io_modes)))
         self._stream = self.open(path, mode=mode, **kwargs)
         self._mode = mode
-        if self.mode not in self.io_modes:
-            raise ValueError("Mode '{mode}' is unsupported: {io_modes}"
-                             .format(mode=self.mode, io_modes=str(self.io_modes)))
 
     def __repr__(self):
         return "<%s driver %s, mode '%s'>" % (

--- a/gpsdio/base.py
+++ b/gpsdio/base.py
@@ -52,9 +52,8 @@ class BaseDriver(six.with_metaclass(_RegisterDriver, object)):
     by_extension = {}
     register = False
     io_modes = ('r', 'w', 'a')
-    mode = 'r'
 
-    def __init__(self, stream):
+    def __init__(self, stream, mode):
 
         """
         Creates an object that transparently interacts with all supported drivers
@@ -67,6 +66,7 @@ class BaseDriver(six.with_metaclass(_RegisterDriver, object)):
         """
 
         self._stream = stream
+        self._mode = mode
         if self.mode not in self.io_modes:
             raise ValueError("Mode {mode} is unsupported - {io_modes}"
                              .format(mode=self.mode, io_modes=str(self.io_modes)))
@@ -97,6 +97,10 @@ class BaseDriver(six.with_metaclass(_RegisterDriver, object)):
         """
 
         return self._stream
+
+    @property
+    def mode(self):
+        return self._mode
 
     def next(self):
 

--- a/gpsdio/drivers.py
+++ b/gpsdio/drivers.py
@@ -106,7 +106,8 @@ class NewlineJSON(_BaseDriver):
 
         _BaseDriver.__init__(
             self,
-            newlinejson.open(f, mode=mode, **kwargs)
+            newlinejson.open(f, mode=mode, **kwargs),
+            mode=mode
         )
 
 
@@ -218,14 +219,16 @@ class MsgPack(_BaseDriver):
         else:
             self._f = f
         if mode == 'r':
-           _BaseDriver.__init__(
+            _BaseDriver.__init__(
                 self,
-                self._MsgPackReader(self._f, **kwargs)
+                self._MsgPackReader(self._f, **kwargs),
+                mode=mode
             )
         else:
-           _BaseDriver.__init__(
+            _BaseDriver.__init__(
                 self,
-                self._MsgPackWriter(self._f, **kwargs)
+                self._MsgPackWriter(self._f, **kwargs),
+                mode=mode
             )
 
 
@@ -257,14 +260,16 @@ class GZIP(_BaseCompressionDriver):
         """
 
         if isinstance(f, six.string_types):
-           _BaseDriver.__init__(
+            _BaseDriver.__init__(
                 self,
-                gzip.open(f, mode=mode, **kwargs)
+                gzip.open(f, mode=mode, **kwargs),
+                mode=mode
             )
         else:
-           _BaseDriver.__init__(
+            _BaseDriver.__init__(
                 self,
-                gzip.GzipFile(fileobj=f, mode=mode, **kwargs)
+                gzip.GzipFile(fileobj=f, mode=mode, **kwargs),
+                mode=mode
             )
 
 
@@ -294,7 +299,8 @@ class BZ2(_BaseCompressionDriver):
 
         _BaseCompressionDriver.__init__(
             self,
-            bz2.BZ2File(f, mode=mode, **kwargs)
+            bz2.BZ2File(f, mode=mode, **kwargs),
+            mode=mode
         )
 
 

--- a/gpsdio/drivers.py
+++ b/gpsdio/drivers.py
@@ -85,30 +85,8 @@ class NewlineJSON(_BaseDriver):
     driver_name = 'NewlineJSON'
     extensions = ('json', 'nljson')
 
-    def __init__(self, f, mode='r', **kwargs):
-
-        """
-        The object returned by `newlinejson.open()` has all of the methods
-        required by `BaseDriver()` so this constructor is pretty sparse.  The
-        `newlinejson.open()` function handles all of the file opening/closing
-        and the returned object is passed directly to `BaseDriver()`.
-
-        Parameters
-        ----------
-        f : str or `newlinejson.Stream()`
-            Path to a file that can be opened by `newlinejson.open()` or a fully
-            instantiated `newlinejson.Stream()` object.
-        mode : str, optional
-            I/O mode for `newlinejson.open()`.
-        kwargs : **kwargs, optional
-            Additional keyword arguments for `newlinejson.open()`.
-        """
-
-        _BaseDriver.__init__(
-            self,
-            newlinejson.open(f, mode=mode, **kwargs),
-            mode=mode
-        )
+    def open(self, f, mode='r', **kwargs):
+        return newlinejson.open(f, mode=mode, **kwargs)
 
 
 class MsgPack(_BaseDriver):
@@ -196,7 +174,7 @@ class MsgPack(_BaseDriver):
 
             return getattr(self._f, item)
 
-    def __init__(self, f, mode='r', **kwargs):
+    def open(self, f, mode='r', **kwargs):
 
         """
         Constructs the necessary objects for reading or writing and hands them
@@ -215,21 +193,13 @@ class MsgPack(_BaseDriver):
         """
 
         if isinstance(f, six.string_types):
-            self._f = codecs_open(f, mode=mode)
+            _f = codecs_open(f, mode=mode)
         else:
-            self._f = f
+            _f = f
         if mode == 'r':
-            _BaseDriver.__init__(
-                self,
-                self._MsgPackReader(self._f, **kwargs),
-                mode=mode
-            )
+            return self._MsgPackReader(_f, **kwargs)
         else:
-            _BaseDriver.__init__(
-                self,
-                self._MsgPackWriter(self._f, **kwargs),
-                mode=mode
-            )
+            return self._MsgPackWriter(_f, **kwargs)
 
 
 class GZIP(_BaseCompressionDriver):
@@ -241,36 +211,12 @@ class GZIP(_BaseCompressionDriver):
     driver_name = 'GZIP'
     extensions = 'gz',
 
-    def __init__(self, f, mode='r', **kwargs):
-
-        """
-        Creates an instance of `gzip.GzipFile()` and passes it to `BaseDriver()`.
-
-        If `f` is a string `gzip.open()` is used, otherwise `gzip.GzipFile()` is
-        instantiated directly.
-
-        Parameters
-        ----------
-        f : str or file
-            File path or open file-like object.
-        mode : str, optional
-            I/O mode for the `gzip` library.
-        kwargs : **kwargs, optional
-            Additional keyword arguments for `gzip.open()` or `gzip.GzipFile()`.
-        """
+    def open(self, f, mode='r', **kwargs):
 
         if isinstance(f, six.string_types):
-            _BaseDriver.__init__(
-                self,
-                gzip.open(f, mode=mode, **kwargs),
-                mode=mode
-            )
+            return gzip.open(f, mode=mode, **kwargs)
         else:
-            _BaseDriver.__init__(
-                self,
-                gzip.GzipFile(fileobj=f, mode=mode, **kwargs),
-                mode=mode
-            )
+            return gzip.GzipFile(fileobj=f, mode=mode, **kwargs)
 
 
 class BZ2(_BaseCompressionDriver):
@@ -282,7 +228,7 @@ class BZ2(_BaseCompressionDriver):
     driver_name = 'BZ2'
     extensions = 'bz2',
 
-    def __init__(self, f, mode='r', **kwargs):
+    def open(self, f, mode='r', **kwargs):
 
         """
         All arguments are passed directly to `bz2.BZFile()`.
@@ -297,11 +243,7 @@ class BZ2(_BaseCompressionDriver):
             Additional keyword arguments for `bz2.BZFile()`.
         """
 
-        _BaseCompressionDriver.__init__(
-            self,
-            bz2.BZ2File(f, mode=mode, **kwargs),
-            mode=mode
-        )
+        return bz2.BZ2File(f, mode=mode, **kwargs)
 
 
 # Register external drivers

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -218,6 +218,12 @@ def test_filter():
         assert len(passed) >= 1
 
 
+def test_mode_passed_to_driver(tmpdir):
+    outfile = str(tmpdir.mkdir('out').join('outfile.msg.gz'))
+    with gpsdio.open(outfile, 'w') as dst:
+        assert dst._stream.mode == dst.mode == 'w'
+
+
 # class TestBaseDriver(unittest.TestCase):
 #
 #     def test_attrs(self):

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -37,7 +37,7 @@ def test_driver_read_matrix():
     for odrv in open_drivers:
         odrv.close()
 
-        stream = odrv.stream
+        stream = odrv._stream
         while stream:
             assert stream.closed, stream
             if hasattr(stream, '_f'):


### PR DESCRIPTION
Closes #99 and partially addresses #106.

The biggest change here is the implementation of an `open()` method for each driver, which the `BaseDriver()` calls on instantiation.  This prevents the user from having to manage their own `__init__` and is more pythonic.  `BaseDriver()` can now also verify that the I/O mode is valid, although it may crash before it reaches the `BaseDriver()`.  For example, this will raise an exception in the NewlineJSON library rather than in `BaseDriver()`.  We could probably just rely on the underlying opening/closing for handling I/O mode validation but lets keep it to a simple `r | w | a` for now.

```python
with gpsdio.open('something.json', 'bad-mode') as dst:
    pass
```