### PR TITLE
Allow gpsdio.open() and drivers to operate on already open files

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,18 +2,21 @@
 
 
 import itertools
+import gzip
 import tempfile
 import unittest
 
-import pytest
+import newlinejson as nlj
 import six
 
 from . import compare_msg
 import gpsdio
 import gpsdio.schema
 import gpsdio.drivers
-import gpsdio.pycompat
-from .sample_files import *
+from .sample_files import TYPES_MSG_FILE
+from .sample_files import TYPES_MSG_GZ_FILE
+from .sample_files import TYPES_JSON_FILE
+from .sample_files import TYPES_JSON_GZ_FILE
 
 
 VALID_ROWS = [
@@ -222,6 +225,26 @@ def test_mode_passed_to_driver(tmpdir):
     outfile = str(tmpdir.mkdir('out').join('outfile.msg.gz'))
     with gpsdio.open(outfile, 'w') as dst:
         assert dst._stream.mode == dst.mode == 'w'
+
+
+def test_io_open_file_pointer():
+    # msg gz
+    with gzip.open(TYPES_MSG_GZ_FILE) as gz, \
+            gpsdio.open(gz, driver='MsgPack', compression='GZIP') as actual, \
+            gpsdio.open(TYPES_JSON_GZ_FILE) as expected:
+        for e, a in zip(expected, actual):
+            assert e == a
+    # json gz
+    with gzip.open(TYPES_JSON_GZ_FILE) as gz, \
+            gpsdio.open(gz, drver='NewlineJSON', compression='GZIP') as actual, \
+            gpsdio.open(TYPES_JSON_GZ_FILE) as expected:
+        for e, a in zip(expected, actual):
+            assert e == a
+    # json fully opened
+    with nlj.open(TYPES_JSON_FILE) as f, gpsdio.open(f, driver='NewlineJSON') as actual, \
+            gpsdio.open(TYPES_JSON_FILE) as expected:
+        for e, a in zip(expected, actual):
+            assert e == a
 
 
 # class TestBaseDriver(unittest.TestCase):


### PR DESCRIPTION
Closes #104.

@pwoods25443 we may find that this does not completely close #104 once we actually test it, but its a good start, and worth implementing anyway.

Supports syntax like:

```python
import gzip
import gpsdio

with gzip.open(path) as gz, gpsdio.open(gz, compression='GZIP', driver=<name>) as src:
    print(next(src))
```

Which we need for Luigi's file targets:

```python
import luigi
from luigi.contrib.gcs import GCSTarget
import gpsdio

class Convert(luigi.Task):
    infile = luigi.Parameter()
    outfile = luigi.Parameter()

    def input(self):
        return GCSTarget(self.infile)

    def output(self):
       return GCSTarget(self.outfile)
    
    def run(self):
        with gpsdio.open(self.input.open(), driver='NewlineJSON') as src,
                 gpsdio.open(self.output.open('w'), 'w', driver='MsgPack', compression='GZIP') as dst:
            for msg in src:
                dst.write(msg)
```

Not very pretty, but it works.