### PR TITLE
Rename gpsdio.core.Stream as GPSDIOStream for better type checking.

### DIFF
--- a/gpsdio/core.py
+++ b/gpsdio/core.py
@@ -125,13 +125,13 @@ def open(path, mode='r', dmode=None, cmode=None, compression=None, driver=None,
 
     log.debug("Built base I/O stream: %s", stream)
 
-    return Stream(stream, mode=mode, **kwargs)
+    return GPSDIOStream(stream, mode=mode, **kwargs)
 
 
-class Stream(object):
+class GPSDIOStream(object):
 
     def __init__(self, stream, mode='r', force_msg=False, keep_fields=True,
-                 skip_failures=False, convert=True, **kwargs):
+                 skip_failures=False, convert=True):
 
         """
         Read or write a stream of AIS data.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,4 @@
-"""Unittests for `gpsdio.core`."""
+"""Unittests for `gpsdio.core`"""
 
 
 import itertools
@@ -227,7 +227,7 @@ def test_io_open_file_pointer():
             assert e == a
     # json gz
     with gzip.open(TYPES_JSON_GZ_FILE) as gz, \
-            gpsdio.open(gz, drver='NewlineJSON', compression='GZIP') as actual, \
+            gpsdio.open(gz, driver='NewlineJSON', compression='GZIP') as actual, \
             gpsdio.open(TYPES_JSON_GZ_FILE) as expected:
         for e, a in zip(expected, actual):
             assert e == a


### PR DESCRIPTION
Closes #128 